### PR TITLE
set monitoring to disabled by default, only generate certificates if `certificates.generate` is true, fix hardcoded namespace for cert DNS names

### DIFF
--- a/charts/cloudnative-pg-tenant/Chart.yaml
+++ b/charts/cloudnative-pg-tenant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cnpg-tenant
 description: Create postgres tenant clusters managed by the CNPG Operator
 type: application
-version: 0.0.9
+version: 0.1.0
 
 maintainers:
   - name: "cloudymax"

--- a/charts/cloudnative-pg-tenant/README.md
+++ b/charts/cloudnative-pg-tenant/README.md
@@ -1,6 +1,6 @@
 # cnpg-tenant
 
-![Version: 0.0.9](https://img.shields.io/badge/Version-0.0.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Create postgres tenant clusters managed by the CNPG Operator
 
@@ -22,14 +22,14 @@ Create postgres tenant clusters managed by the CNPG Operator
 | backup.retentionPolicy | string | `"30d"` | how long to keep backups for |
 | bootstrap.initdb.database | string | `"app"` | initial database to create |
 | bootstrap.initdb.owner | string | `"app"` | owner of the initial database that is created above |
-| bootstrap.initdb.postInitSQL | list | `["CREATE ROLE friend"]` | list of SQL commands to run as part of the init scripts |
 | bootstrap.initdb.secret.name | string | `"app-secret"` |  |
-| certificates.clientCASecret | string | `"my-postgres-client-cert"` | name of existing Kubernetes Secret for the postgresql client Certificate Authority cert |
-| certificates.replicationTLSSecret | string | `"my-postgres-client-cert"` | name of existing Kubernetes Secret for the postgresql client TLS cert |
-| certificates.serverCASecret | string | `"my-postgres-server-cert"` | name of existing Kubernetes Secret for the postgresql server Certificate Authority cert |
-| certificates.serverTLSSecret | string | `"my-postgres-server-cert"` | name of existing Kubernetes Secret for the postgresql server TLS cert |
+| certificates.clientCASecret | string | `"my-postgres-client-cert"` | name of existing Kubernetes Secret for the postgresql client Certificate Authority cert, ignored if certificates.generate is true |
+| certificates.generate | bool | `true` | generate server and client certs using cert-manager. if true the following  are ignored: certificates.serverTLSSecret, certificates.serverCASecret, certificates.clientCASecret, and certificates.replicationTLSSecret |
+| certificates.replicationTLSSecret | string | `"my-postgres-client-cert"` | name of existing Kubernetes Secret for the postgresql client TLS cert ignored if certificates.generate is true |
+| certificates.serverCASecret | string | `"my-postgres-server-cert"` | name of existing Kubernetes Secret for the postgresql server Certificate Authority cert, ignored if certificates.generate is true |
+| certificates.serverTLSSecret | string | `"my-postgres-server-cert"` | name of existing Kubernetes Secret for the postgresql server TLS cert, ignored if certificates.generate is true |
 | instances | int | `3` |  |
-| monitoring.enablePodMonitor | bool | `true` | enable monitoring via Prometheus |
+| monitoring.enablePodMonitor | bool | `false` | enable monitoring via Prometheus |
 | name | string | `"cnpg"` |  |
 | postgresql.pg_hba | list | `["hostnossl all all 0.0.0.0/0 reject","hostssl all all 0.0.0.0/0 cert clientcert=verify-full"]` | records for the pg_hba.conf file. ref: https://www.postgresql.org/docs/current/auth-pg-hba-conf.html |
 | scheduledBackup.name | string | `"example-backup"` | name to use for your scheduled backup job |

--- a/charts/cloudnative-pg-tenant/templates/client_certificates.yaml
+++ b/charts/cloudnative-pg-tenant/templates/client_certificates.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.certificates.generate }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -43,3 +44,4 @@ spec:
     name: "{{ .Values.name }}-client-ca-issuer"
     kind: Issuer
     group: cert-manager.io
+{{- end }}

--- a/charts/cloudnative-pg-tenant/templates/cluster_certificates.yaml
+++ b/charts/cloudnative-pg-tenant/templates/cluster_certificates.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.certificates.generate }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Issuer
@@ -60,4 +61,4 @@ spec:
     name: "{{ .Values.name }}-server-ca-issuer"
     kind: Issuer
     group: cert-manager.io
-
+{{- end }}

--- a/charts/cloudnative-pg-tenant/templates/cluster_certificates.yaml
+++ b/charts/cloudnative-pg-tenant/templates/cluster_certificates.yaml
@@ -47,16 +47,15 @@ spec:
   usages:
     - server auth
   dnsNames:
-    - "{{ .Values.name }}-lb.internal.mydomain.net"
     - "{{ .Values.name }}-rw"
-    - "{{ .Values.name }}-rw.default"
-    - "{{ .Values.name }}-rw.default.svc"
+    - "{{ .Values.name }}-rw.{{ .Release.Namespace }}"
+    - "{{ .Values.name }}-rw.{{ .Release.Namespace }}.svc"
     - "{{ .Values.name }}-r"
-    - "{{ .Values.name }}-r.default"
-    - "{{ .Values.name }}-r.default.svc"
+    - "{{ .Values.name }}-r.{{ .Release.Namespace }}"
+    - "{{ .Values.name }}-r.{{ .Release.Namespace }}.svc"
     - "{{ .Values.name }}-ro"
-    - "{{ .Values.name }}-ro.default"
-    - "{{ .Values.name }}-ro.default.svc"
+    - "{{ .Values.name }}-ro.{{ .Release.Namespace }}"
+    - "{{ .Values.name }}-ro.{{ .Release.Namespace }}.svc"
   issuerRef:
     name: "{{ .Values.name }}-server-ca-issuer"
     kind: Issuer

--- a/charts/cloudnative-pg-tenant/templates/tenant.yaml
+++ b/charts/cloudnative-pg-tenant/templates/tenant.yaml
@@ -24,8 +24,8 @@ spec:
   {{- if .Values.certificates.generate }}
   certificates:
     serverTLSSecret: "{{ .Values.name }}-server-cert"
-    serverCASecret: "{{ .Values.name }}-server-ca"
-    clientCASecret: "{{ .Values.name }}-client-ca"
+    serverCASecret: "{{ .Values.name }}-server-ca-key-pair"
+    clientCASecret: "{{ .Values.name }}-client-ca-key-pair"
     replicationTLSSecret: "{{ .Values.name }}-client-cert"
   {{ else }}
   {{- with .Values.certificates }}

--- a/charts/cloudnative-pg-tenant/templates/tenant.yaml
+++ b/charts/cloudnative-pg-tenant/templates/tenant.yaml
@@ -23,9 +23,9 @@ spec:
   {{- end }}
   {{- if .Values.certificates.generate }}
   certificates:
-    serverTLSSecret: "{{ .Values.name}}-server-cert"
-    serverCASecret: "{{ .Values.name}}-server-ca"
-    clientCASecret: "{{ .Values.name}}-client-ca"
+    serverTLSSecret: "{{ .Values.name }}-server-cert"
+    serverCASecret: "{{ .Values.name }}-server-ca"
+    clientCASecret: "{{ .Values.name }}-client-ca"
     replicationTLSSecret: "{{ .Values.name }}-client-cert"
   {{ else }}
   {{- with .Values.certificates }}

--- a/charts/cloudnative-pg-tenant/templates/tenant.yaml
+++ b/charts/cloudnative-pg-tenant/templates/tenant.yaml
@@ -5,9 +5,6 @@ metadata:
   name: {{ .Values.name }}
 spec:
   instances: {{ .Values.instances}}
-  certificates:
-    clientCASecret: "{{ .Values.name}}-client-cert"
-    replicationTLSSecret: "{{ .Values.name }}-client-cert"
   {{- with .Values.backup }}
   backup:
     {{- toYaml . | nindent 4 }}
@@ -24,7 +21,15 @@ spec:
   bootstrap:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- if .Values.certificates.generate }}
+  certificates:
+    serverTLSSecret: "{{ .Values.name}}-server-cert"
+    serverCASecret: "{{ .Values.name}}-server-ca"
+    clientCASecret: "{{ .Values.name}}-client-ca"
+    replicationTLSSecret: "{{ .Values.name }}-client-cert"
+  {{ else }}
   {{- with .Values.certificates }}
   certificates:
     {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}

--- a/charts/cloudnative-pg-tenant/values.yaml
+++ b/charts/cloudnative-pg-tenant/values.yaml
@@ -45,7 +45,7 @@ scheduledBackup:
       name: pg-backup
 
 certificates:
-  # -- generate server and client certs using cert-manager. if true the following 
+  # -- generate server and client certs using cert-manager. if true the following
   # are ignored: certificates.serverTLSSecret, certificates.serverCASecret,
   # certificates.clientCASecret, and certificates.replicationTLSSecret
   generate: true

--- a/charts/cloudnative-pg-tenant/values.yaml
+++ b/charts/cloudnative-pg-tenant/values.yaml
@@ -14,8 +14,9 @@ bootstrap:
     secret:
       name: app-secret
     # -- list of SQL commands to run as part of the init scripts
-    postInitSQL:
-      - CREATE ROLE friend
+    postInitSQL: []
+    # example init command:
+    #  - CREATE ROLE friend
 
 backup:
   # -- how long to keep backups for

--- a/charts/cloudnative-pg-tenant/values.yaml
+++ b/charts/cloudnative-pg-tenant/values.yaml
@@ -13,9 +13,8 @@ bootstrap:
     owner: app
     secret:
       name: app-secret
-    # -- list of SQL commands to run as part of the init scripts
-    postInitSQL: []
-    # example init command:
+    # list of SQL commands to run as part of the init scripts, example:
+    # postInitSQL:
     #  - CREATE ROLE friend
 
 backup:
@@ -46,18 +45,26 @@ scheduledBackup:
       name: pg-backup
 
 certificates:
-  # -- name of existing Kubernetes Secret for the postgresql server TLS cert
+  # -- generate server and client certs using cert-manager. if true the following 
+  # are ignored: certificates.serverTLSSecret, certificates.serverCASecret,
+  # certificates.clientCASecret, and certificates.replicationTLSSecret
+  generate: true
+  # -- name of existing Kubernetes Secret for the postgresql server TLS cert,
+  # ignored if certificates.generate is true
   serverTLSSecret: my-postgres-server-cert
-  # -- name of existing Kubernetes Secret for the postgresql server Certificate Authority cert
+  # -- name of existing Kubernetes Secret for the postgresql server Certificate
+  # Authority cert, ignored if certificates.generate is true
   serverCASecret: my-postgres-server-cert
-  # -- name of existing Kubernetes Secret for the postgresql client Certificate Authority cert
+  # -- name of existing Kubernetes Secret for the postgresql client Certificate
+  # Authority cert, ignored if certificates.generate is true
   clientCASecret: my-postgres-client-cert
   # -- name of existing Kubernetes Secret for the postgresql client TLS cert
+  # ignored if certificates.generate is true
   replicationTLSSecret: my-postgres-client-cert
 
 monitoring:
   # -- enable monitoring via Prometheus
-  enablePodMonitor: true
+  enablePodMonitor: false
 
 postgresql:
   # -- records for the pg_hba.conf file. ref: https://www.postgresql.org/docs/current/auth-pg-hba-conf.html


### PR DESCRIPTION
- set monitoring to disabled by default
- add `certificates.generate` boolean parameter to only generate certs via cert manager if that is true, which will be the default
- change all hardcoded default namespace to `{{ .Release.Namespace }}`