### PR TITLE
fix conflict between initdb and recovery options in bootstrap menu

### DIFF
--- a/charts/cloudnative-pg-cluster/Chart.yaml
+++ b/charts/cloudnative-pg-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cnpg-cluster
 description: Create postgres tenant clusters managed by the CNPG Operator
 type: application
-version: 0.3.5
+version: 0.3.6
 
 maintainers:
   - name: "cloudymax"

--- a/charts/cloudnative-pg-cluster/README.md
+++ b/charts/cloudnative-pg-cluster/README.md
@@ -1,6 +1,6 @@
 # cnpg-cluster
 
-![Version: 0.3.5](https://img.shields.io/badge/Version-0.3.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.3.6](https://img.shields.io/badge/Version-0.3.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Create postgres tenant clusters managed by the CNPG Operator
 
@@ -34,6 +34,7 @@ Create postgres tenant clusters managed by the CNPG Operator
 | certificates.server.serverTLSSecret | string | `""` | name of existing Kubernetes Secret for the postgresql server TLS cert, ignored if certificates.generate is true |
 | certificates.user.enabled | bool | `false` | create a certificate for a user to connect to postgres using CertManager requires server and client certificate generation enabled |
 | certificates.user.username | string | `"app"` | name of the user to create a cert for, eg: the DbOwner specified earlier. This data populated into the commonName field of the certificate. |
+| externalClusters | list | `[]` |  |
 | instances | int | `3` |  |
 | monitoring.enablePodMonitor | bool | `false` | enable monitoring via Prometheus |
 | name | string | `"cnpg"` |  |

--- a/charts/cloudnative-pg-cluster/templates/cnpg_cluster.yaml
+++ b/charts/cloudnative-pg-cluster/templates/cnpg_cluster.yaml
@@ -26,10 +26,19 @@ spec:
   {{- end }}
   storage:
     size: {{ .Values.storage.size }}
-  {{- with .Values.bootstrap }}
   bootstrap:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- if .Values.bootstrap.initdb }}
+    {{- with .Values.bootstrap.initdb }}
+    initdb:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- end }}
+    {{- if .Values.bootstrap.recovery }}
+    {{- with .Values.bootstrap.recovery }}   
+    recovery:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- end }}
   {{- if or .Values.certificates.server.enabled .Values.certificates.client.enabled }}
   certificates:
   {{- if and .Values.certificates.server.enabled }}

--- a/charts/cloudnative-pg-cluster/values.yaml
+++ b/charts/cloudnative-pg-cluster/values.yaml
@@ -14,8 +14,8 @@ bootstrap:
     # postInitSQL:
     #  - CREATE ROLE friend
     # Specify an external cluster to bootstrap from
-    # recovery:
-    #  source: clusterBackup
+  # recovery:
+  #   source: clusterBackup
 
 externalClusters: []
 #  # -- name of external/existing cluster


### PR DESCRIPTION
Previously, bootstrap would always render the initdb section with a password field due to how the default values.yaml was parsed:

```yaml
  bootstrap:
    initdb:
      secret:                       <----- this guy
        name: app-secret
    recovery:
      source: cnpg
```

This would cause a conflict when trying to use the recovery option:

```console
helm install cnpg-cluster cnpg-cluster/cnpg-cluster --values restore-values.yaml
Error: INSTALLATION FAILED: 1 error occurred:
        * admission webhook "vcluster.cnpg.io" denied the request: Cluster.postgresql.cnpg.io "cnpg2" is invalid: [spec.bootstrap: Invalid value: "": Too many bootstrap types specified, spec.bootstrap.recovery.source: Invalid value: "cnpg": External cluster cnpg not found]
```

It should now properly skip rendering the initdb section when no values are specified for it