### PR TITLE
FEAT: enable cert creation for multiple users

### DIFF
--- a/.github/workflows/ci-helm-lint-test.yml
+++ b/.github/workflows/ci-helm-lint-test.yml
@@ -95,7 +95,8 @@ jobs:
               replicationTLSSecret: ""
             user:
               enabled: true
-              username: "app"
+              username: 
+                - "app"
           monitoring:
             enablePodMonitor: false
           postgresql:

--- a/charts/cloudnative-pg-cluster/Chart.yaml
+++ b/charts/cloudnative-pg-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cnpg-cluster
 description: Create postgres tenant clusters managed by the CNPG Operator
 type: application
-version: 0.3.8
+version: 0.3.9
 
 maintainers:
   - name: "cloudymax"

--- a/charts/cloudnative-pg-cluster/README.md
+++ b/charts/cloudnative-pg-cluster/README.md
@@ -1,6 +1,6 @@
 # cnpg-cluster
 
-![Version: 0.3.8](https://img.shields.io/badge/Version-0.3.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.3.9](https://img.shields.io/badge/Version-0.3.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Create postgres tenant clusters managed by the CNPG Operator
 
@@ -33,7 +33,7 @@ Create postgres tenant clusters managed by the CNPG Operator
 | certificates.server.serverCASecret | string | `""` | name of existing Kubernetes Secret for the postgresql server Certificate Authority cert, ignored if certificates.generate is true |
 | certificates.server.serverTLSSecret | string | `""` | name of existing Kubernetes Secret for the postgresql server TLS cert, ignored if certificates.generate is true |
 | certificates.user.enabled | bool | `false` | create a certificate for a user to connect to postgres using CertManager requires server and client certificate generation enabled |
-| certificates.user.username | string | `"app"` | name of the user to create a cert for, eg: the DbOwner specified earlier. This data populated into the commonName field of the certificate. |
+| certificates.user.username | list | `["app"]` | List of names of users to create a cert for, eg: the DbOwner specified earlier. This data populated into the commonName field of the certificate. |
 | enableSuperuserAccess | bool | `false` | CNPG disables the postgres superuser by default must be explicitly enabled |
 | externalClusters | list | `[]` |  |
 | imageName | string | `"ghcr.io/cloudnative-pg/postgresql:16.0"` | image to use for all tenant pods |

--- a/charts/cloudnative-pg-cluster/templates/user_certificates.yaml
+++ b/charts/cloudnative-pg-cluster/templates/user_certificates.yaml
@@ -1,23 +1,25 @@
 {{- if and .Values.certificates.user.enabled }}
+{{- range .Values.certificates.user.username }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: "{{ .Values.name }}-{{ .Values.certificates.user.username }}-cert"
+  name: "{{ $.Values.name }}-{{ . }}-cert"
   labels:
     cnpg.io/reload: ""
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: "{{ .Values.name }}-{{ .Values.certificates.user.username }}-cert"
+  name: "{{ $.Values.name }}-{{ . }}-cert"
 spec:
-  secretName: "{{ .Values.name }}-{{ .Values.certificates.user.username }}-cert"
+  secretName: "{{ $.Values.name }}-{{ . }}-cert"
   usages:
     - client auth
-  commonName: {{ .Values.certificates.user.username }}
+  commonName: {{ . }}
   issuerRef:
-    name: "{{ .Values.name }}-client-ca-issuer" 
+    name: "{{ $.Values.name }}-client-ca-issuer" 
     kind: Issuer
     group: cert-manager.io
+{{- end }}
 {{- end }}

--- a/charts/cloudnative-pg-cluster/values.yaml
+++ b/charts/cloudnative-pg-cluster/values.yaml
@@ -114,9 +114,10 @@ certificates:
     # -- create a certificate for a user to connect to postgres using CertManager
     # requires server and client certificate generation enabled
     enabled: false
-    # -- name of the user to create a cert for, eg: the DbOwner specified earlier.
+    # -- List of names of users to create a cert for, eg: the DbOwner specified earlier.
     # This data populated into the commonName field of the certificate.
-    username: "app"
+    username:
+      - "app"
 
 monitoring:
   # -- enable monitoring via Prometheus


### PR DESCRIPTION
This adds the ability to create certificates for multiple users at time of creation.


BREAKING CHANGES:
- .Values.certificates.user.username is now a list of strings instead of a single string

old:

```yaml
username: "app"
```

new:

```yaml
username: 
  - "app"
  - "postgres"
```
