### PR TITLE
attempt to fix user certs with _ in the name to have - in the secret and cert name

### DIFF
--- a/charts/cloudnative-pg-cluster/Chart.yaml
+++ b/charts/cloudnative-pg-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cnpg-cluster
 description: Create postgres tenant clusters managed by the CNPG Operator
 type: application
-version: 0.3.10
+version: 0.3.11
 
 maintainers:
   - name: "cloudymax"

--- a/charts/cloudnative-pg-cluster/README.md
+++ b/charts/cloudnative-pg-cluster/README.md
@@ -1,6 +1,6 @@
 # cnpg-cluster
 
-![Version: 0.3.10](https://img.shields.io/badge/Version-0.3.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.3.11](https://img.shields.io/badge/Version-0.3.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Create postgres tenant clusters managed by the CNPG Operator
 

--- a/charts/cloudnative-pg-cluster/templates/user_certificates.yaml
+++ b/charts/cloudnative-pg-cluster/templates/user_certificates.yaml
@@ -1,19 +1,20 @@
 {{- if and .Values.certificates.user.enabled }}
 {{- range .Values.certificates.user.username }}
+{{- $username := . | replace "_" "-" -}}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: "{{ $.Values.name }}-{{ . }}-cert"
+  name: "{{ $.Values.name }}-{{ $username }}-cert"
   labels:
     cnpg.io/reload: ""
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: "{{ $.Values.name }}-{{ . }}-cert"
+  name: "{{ $.Values.name }}-{{ $username }}-cert"
 spec:
-  secretName: "{{ $.Values.name }}-{{ . }}-cert"
+  secretName: "{{ $.Values.name }}-{{ $username }}-cert"
   usages:
     - client auth
   commonName: {{ . }}


### PR DESCRIPTION
# Description

This is to avoid these errors when generating a cert for a user with an `_` like `supabase_auth_admin` which is required by gotrue and appflowy:

> v1/Secret appflowy appflowy-postgres-supabase_auth_admin-cert SyncFailed
> Secret "appflowy-postgres-supabase_auth_admin-cert" is invalid: metadata.name: Invalid value: "appflowy-postgres-supabase_auth_admin-cert": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')


> cert-manager.io/v1/Certificate appflowy appflowy-postgres-supabase_auth_admin-cert SyncFailed
> Certificate.cert-manager.io "appflowy-postgres-supabase_auth_admin-cert" is invalid: metadata.name: Invalid value: "appflowy-postgres-supabase_auth_admin-cert": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')

As seen in Argo CD (alt text is the two above quoted text blocks):
<img width="1197" alt="Screenshot of argo cd interface showing the two above errors" src="https://github.com/small-hack/cloudnative-pg-cluster-chart/assets/2389292/c5e1dd71-b529-48c3-b96a-0a3923be8e46">

# Testing

I tried this:
```bash
helm template . --set certificates.user.enabled=true --set certificates.user.username[0]="jesse_bot"
```

which produces this:

```yaml
---
# Source: cnpg-cluster/templates/user_certificates.yaml
apiVersion: v1
kind: Secret
metadata:
  name: "cnpg-jesse-bot-cert"
  labels:
    cnpg.io/reload: ""
---
# Source: cnpg-cluster/templates/user_certificates.yaml
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: "cnpg-jesse-bot-cert"
spec:
  secretName: "cnpg-jesse-bot-cert"
  usages:
    - client auth
  commonName: jesse_bot
  issuerRef:
    name: "cnpg-client-ca-issuer"
    kind: Issuer
    group: cert-manager.io
```

hopefully that works? 🤷 