### PR TITLE
make the bootstrap section empty by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,11 @@ helm show values cnpg/cnpg-cluster > values.yaml
 # install the chart
 helm install cnpg cnpg/cnpg-cluster --values values.yaml
 ```
+
+## Notes
+
+### You must specify a bootstrap section
+
+To use this chart you _have_ to specify either `bootstrap.initdb.database`/`bootstrap.initdb.owner` OR `bootstrap.recovery.source` in your helm parameters or values.yaml but you can't do both.
+
+You can see checkout the [CloudNativePG docs](https://cloudnative-pg.io/documentation/1.23/bootstrap/) for more info on the bootstrap section.

--- a/charts/cloudnative-pg-cluster/Chart.yaml
+++ b/charts/cloudnative-pg-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cnpg-cluster
 description: Create postgres tenant clusters managed by the CNPG Operator
 type: application
-version: 0.3.15
+version: 0.4.0
 
 maintainers:
   - name: "cloudymax"

--- a/charts/cloudnative-pg-cluster/README.md
+++ b/charts/cloudnative-pg-cluster/README.md
@@ -1,6 +1,6 @@
 # cnpg-cluster
 
-![Version: 0.3.14](https://img.shields.io/badge/Version-0.3.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Create postgres tenant clusters managed by the CNPG Operator
 
@@ -16,8 +16,7 @@ Create postgres tenant clusters managed by the CNPG Operator
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | backup | object | `{}` | if we should backup up this cluster, please see values.yaml for example |
-| bootstrap.initdb.database | string | `"app"` | initial database to create |
-| bootstrap.initdb.owner | string | `"app"` | owner of the initial database that is created above |
+| bootstrap | object | `{}` | boostrap method. see: https://cloudnative-pg.io/documentation/1.23/bootstrap/ |
 | certificates.client.clientCASecret | string | `""` | name of existing Kubernetes Secret for the postgresql client Certificate Authority cert, ignored if certificates.generate is true |
 | certificates.client.enabled | bool | `false` | enable using client certificates |
 | certificates.client.generate | bool | `false` | generate client certs using cert-manager. if true the following are ignored: certificates.clientCASecret, certificates.replicationTLSSecret |

--- a/charts/cloudnative-pg-cluster/templates/cnpg_cluster.yaml
+++ b/charts/cloudnative-pg-cluster/templates/cnpg_cluster.yaml
@@ -32,19 +32,10 @@ spec:
   {{- end }}
   storage:
     size: {{ .Values.storage.size }}
+  {{- with .Values.bootstrap }}
   bootstrap:
-    {{- if .Values.bootstrap.initdb }}
-    {{- with .Values.bootstrap.initdb }}
-    initdb:
-      {{- toYaml . | nindent 6 }}
-    {{- end }}
-    {{- end }}
-    {{- if .Values.bootstrap.recovery }}
-    {{- with .Values.bootstrap.recovery }}
-    recovery:
-      {{- toYaml . | nindent 6 }}
-    {{- end }}
-    {{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- if or .Values.certificates.server.enabled .Values.certificates.client.enabled }}
   certificates:
   {{- if and .Values.certificates.server.enabled }}

--- a/charts/cloudnative-pg-cluster/values.yaml
+++ b/charts/cloudnative-pg-cluster/values.yaml
@@ -22,19 +22,23 @@ superuserSecret: ""
 #               the switchover of the primary
 primaryUpdateStrategy: unsupervised
 
-bootstrap:
-  initdb:
-    # -- initial database to create
-    database: app
-    # -- owner of the initial database that is created above
-    owner: app
-    # secret:
-    #  name: app-secret
-    # list of SQL commands to run as part of the init scripts, example:
-    # postInitSQL:
-    #  - CREATE ROLE friend
-    # Specify an external cluster to bootstrap from
+# -- boostrap method. see: https://cloudnative-pg.io/documentation/1.23/bootstrap/
+bootstrap: {}
+  # -- for initializing a fresh cluster
+  # initdb:
+  #  # -- initial database to create
+  #  database: app
+  #  # -- owner of the initial database that is created above
+  #  owner: app
+  #  secret:
+  #   name: app-secret
+  #  list of SQL commands to run as part of the init scripts, example:
+  #  postInitSQL:
+  #   - CREATE ROLE friend
+  #
+  # for restoring a cluster
   # recovery:
+  #   # -- Specify an external cluster to bootstrap from
   #   source: clusterBackup
 
 # -- See https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-RoleConfiguration for explanation of all options


### PR DESCRIPTION
We're making the `bootstrap` parameter an empty map `{}` by default, so that no default `bootstrap.initdb` is created when doing recoveries.