### PR TITLE
Set major version to 17, and allow user to specify storageclass for cluster PVCs

### DIFF
--- a/charts/cloudnative-pg-cluster/Chart.yaml
+++ b/charts/cloudnative-pg-cluster/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 name: cnpg-cluster
 description: Create postgres tenant clusters managed by the CNPG Operator
 type: application
-version: 0.5.0
+version: 0.6.0
 
 maintainers:
   - name: "cloudymax"
     url: "https://github.com/cloudymax"
   - name: "jessebot"
-    url: "https://github.com/jessebot"
+    url: "https://jessebot.work"

--- a/charts/cloudnative-pg-cluster/README.md
+++ b/charts/cloudnative-pg-cluster/README.md
@@ -1,6 +1,6 @@
 # cnpg-cluster
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Create postgres tenant clusters managed by the CNPG Operator
 
@@ -9,7 +9,7 @@ Create postgres tenant clusters managed by the CNPG Operator
 | Name | Email | Url |
 | ---- | ------ | --- |
 | cloudymax |  | <https://github.com/cloudymax> |
-| jessebot |  | <https://github.com/jessebot> |
+| jessebot |  | <https://jessebot.work> |
 
 ## Values
 
@@ -31,7 +31,7 @@ Create postgres tenant clusters managed by the CNPG Operator
 | externalClusters | list | `[]` |  |
 | imageCatalog.create | bool | `true` | Whether to provision an image catalog. If imageCatalog.images is empty this option will be ignored. |
 | imageCatalog.images | list | `[]` | List of images to be provisioned in an image catalog. |
-| imageName | string | `"ghcr.io/cloudnative-pg/postgresql:16.0"` | image to use for all tenant pods |
+| imageName | string | `"ghcr.io/cloudnative-pg/postgresql:17.0"` | image to use for all tenant pods |
 | instances | int | `3` | number of postgres replicas minimum 1 required |
 | managed | object | `{"roles":[]}` | See https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-RoleConfiguration for explanation of all options |
 | monitoring.enablePodMonitor | bool | `false` | enable monitoring via Prometheus |

--- a/charts/cloudnative-pg-cluster/README.md
+++ b/charts/cloudnative-pg-cluster/README.md
@@ -43,6 +43,7 @@ Create postgres tenant clusters managed by the CNPG Operator
 | resources | object | `{}` |  |
 | scheduledBackup | object | `{}` | schduled backups section, please see values.yaml for example |
 | storage.size | string | `"1Gi"` | how much storage to allocate to the postgresql cluster |
+| storage.storageClass | string | `"default"` | set the storage class of the PVC. |
 | superuserSecret | string | `""` | name of existing secret to use as superuser redentials will be randomly generated if not specified. |
 | testApp.enabled | bool | `false` |  |
 | type | string | `"postgresql"` | Type of the CNPG database. Available types: * `postgresql` * `postgis` * `timescaledb` |

--- a/charts/cloudnative-pg-cluster/templates/cnpg_cluster.yaml
+++ b/charts/cloudnative-pg-cluster/templates/cnpg_cluster.yaml
@@ -41,6 +41,9 @@ spec:
   {{- end }}
   storage:
     size: {{ .Values.storage.size }}
+    {{- if ne .Values.storage.storageClass "default" }}
+    storageClass: {{ .Values.storage.storageClass }}
+    {{- end }}
   {{- with .Values.bootstrap }}
   bootstrap:
     {{- toYaml . | nindent 4 }}

--- a/charts/cloudnative-pg-cluster/values.yaml
+++ b/charts/cloudnative-pg-cluster/values.yaml
@@ -5,7 +5,7 @@ name: "cnpg"
 instances: 3
 
 # -- image to use for all tenant pods
-imageName: ghcr.io/cloudnative-pg/postgresql:16.0
+imageName: ghcr.io/cloudnative-pg/postgresql:17.0
 
 # -- CNPG disables the postgres superuser by default
 # must be explicitly enabled
@@ -21,7 +21,7 @@ imageCatalog:
   # -- List of images to be provisioned in an image catalog.
   images: []
     # - image: ghcr.io/your_repo/your_image:your_tag
-    #   major: 16
+    #   major: 17
 
 # Examples of rolling update strategy:
 # unsupervised: automated update of the primary once all

--- a/charts/cloudnative-pg-cluster/values.yaml
+++ b/charts/cloudnative-pg-cluster/values.yaml
@@ -168,6 +168,8 @@ postgresql:
 storage:
   # -- how much storage to allocate to the postgresql cluster
   size: 1Gi
+  # -- set the storage class of the PVC.
+  storageClass: default
 
 # from https://cloudnative-pg.io/documentation/1.22/resource_management/
 resources: {}


### PR DESCRIPTION
We've already done this for our stuff, but we need to update the defaults.

Another PR will set it to 18, so people can upgrade gracefully.